### PR TITLE
fix serialization; other enhancements

### DIFF
--- a/api/Playlister.Tests/Playlister.Tests.csproj
+++ b/api/Playlister.Tests/Playlister.Tests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.0"/>
-    <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
-    <PackageReference Include="Moq" Version="4.20.70"/>
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.71" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.0"/>
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Playlister\Playlister.csproj"/>
+    <ProjectReference Include="..\Playlister\Playlister.csproj" />
   </ItemGroup>
 
 </Project>

--- a/api/Playlister.sln.DotSettings
+++ b/api/Playlister.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isrc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pkce/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=playlister/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/api/Playlister/Data/DataTables.cs
+++ b/api/Playlister/Data/DataTables.cs
@@ -2,7 +2,8 @@ namespace Playlister.Data;
 
 public static class DataTables
 {
-    public const string AccessToken = "AccessToken";
+    [Obsolete( "Not used anymore" )] public const string AccessToken = "AccessToken";
+
     public const string Album = "Album";
     public const string Artist = "Artist";
     public const string Playlist = "Playlist";
@@ -22,4 +23,14 @@ public static class DataTables
     ///     Track/Artist many-to-many relationship
     /// </summary>
     public const string TrackArtist = "TrackArtist";
+
+    /// <summary>
+    ///     External IDs for a Saved Album
+    /// </summary>
+    public const string ExternalId = "ExternalId";
+
+    /// <summary>
+    ///     Albums saved in a Spotify user's 'Your Music' library
+    /// </summary>
+    public const string SavedAlbum = "SavedAlbum";
 }

--- a/api/Playlister/Data/FluentMigratorExtensions.cs
+++ b/api/Playlister/Data/FluentMigratorExtensions.cs
@@ -10,7 +10,7 @@ internal static class FluentMigratorExtensions
     /// </summary>
     /// <param name="tableWithColumnSyntax">The table to add the TrackId column to</param>
     /// <returns></returns>
-    public static ICreateTableColumnOptionOrWithColumnSyntax WithSpotifyIdColumn(
+    public static ICreateTableColumnOptionOrWithColumnSyntax WithSpotifyPrimaryIdColumn(
         this ICreateTableWithColumnSyntax tableWithColumnSyntax
     )
     {

--- a/api/Playlister/Data/Fm001AddTables.cs
+++ b/api/Playlister/Data/Fm001AddTables.cs
@@ -18,7 +18,7 @@ public class Fm001AddPlaylistTable : AutoReversingMigration
     private void CreateTables()
     {
         Create.Table( DataTables.Playlist )
-            .WithSpotifyIdColumn()
+            .WithSpotifyPrimaryIdColumn()
             .WithTimeStamps()
             .WithColumn( "snapshot_id" )
             .AsString()
@@ -38,14 +38,14 @@ public class Fm001AddPlaylistTable : AutoReversingMigration
             .Nullable();
 
         Create.Table( DataTables.Artist )
-            .WithSpotifyIdColumn()
+            .WithSpotifyPrimaryIdColumn()
             .WithTimeStamps()
             .WithColumn( "name" )
             .AsString()
             .NotNullable();
 
         Create.Table( DataTables.Album )
-            .WithSpotifyIdColumn()
+            .WithSpotifyPrimaryIdColumn()
             .WithTimeStamps()
             .WithColumn( "name" )
             .AsString()
@@ -61,7 +61,7 @@ public class Fm001AddPlaylistTable : AutoReversingMigration
             .Nullable();
 
         Create.Table( DataTables.Track )
-            .WithSpotifyIdColumn()
+            .WithSpotifyPrimaryIdColumn()
             .WithTimeStamps()
             .WithColumn( "name" )
             .AsString()

--- a/api/Playlister/Data/Fm003AddAccessTokenTable.cs
+++ b/api/Playlister/Data/Fm003AddAccessTokenTable.cs
@@ -5,7 +5,10 @@ namespace Playlister.Data;
 [Migration( 003, "Add AccessToken table" )]
 public class Fm003AddAccessTokenTable : AutoReversingMigration
 {
+    [Obsolete( "Obsolete" )]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
     public override void Up()
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
     {
         Create.Table( DataTables.AccessToken )
             .WithColumn( "access_token" )

--- a/api/Playlister/Data/Fm004AddPlaylistCountColumn.cs
+++ b/api/Playlister/Data/Fm004AddPlaylistCountColumn.cs
@@ -2,7 +2,7 @@ using FluentMigrator;
 
 namespace Playlister.Data;
 
-[Migration( 004, "Add 'count' columne to the Playlist table" )]
+[Migration( 004, "Add 'count' column to the Playlist table" )]
 public class Fm004AddPlaylistCountColumn : AutoReversingMigration
 {
     public override void Up()

--- a/api/Playlister/Data/Fm006AddUniqueCountToPlaylist.cs
+++ b/api/Playlister/Data/Fm006AddUniqueCountToPlaylist.cs
@@ -3,7 +3,7 @@ using FluentMigrator;
 namespace Playlister.Data;
 
 [Migration( 006, "Add a 'unique_count' field to Playlist so that we can track the number of unique tracks on a Playlist" )]
-public class Fm007AddUniqueCount : AutoReversingMigration
+public class Fm006AddUniqueCount : AutoReversingMigration
 {
     public override void Up()
     {

--- a/api/Playlister/Data/Fm008AddAlbumFields.cs
+++ b/api/Playlister/Data/Fm008AddAlbumFields.cs
@@ -1,0 +1,42 @@
+using FluentMigrator;
+
+namespace Playlister.Data;
+
+[Migration( 008, "Create new tables for ExcludedIds and Saved Albums" )]
+public class Fm008AddAlbumFields : Migration
+{
+    public override void Up()
+    {
+        Create.Table( DataTables.SavedAlbum )
+            .WithSpotifyPrimaryIdColumn()
+            .WithTimeStamps()
+            .WithColumn( "label" )
+            .AsString()
+            .NotNullable()
+            .ForeignKey( "fk_savedalbum_album", DataTables.Album, "id" );
+
+        Create.Table( DataTables.ExternalId )
+            .WithColumn( "album_id" )
+            .AsString()
+            .NotNullable()
+            .PrimaryKey()
+            .WithTimeStamps()
+            .WithColumn( "ean" )
+            .AsString()
+            .Nullable()
+            .WithColumn( "isrc" )
+            .AsString()
+            .Nullable()
+            .WithColumn( "upc" )
+            .AsString()
+            .Nullable()
+            .ForeignKey( "fk_externalid_album", DataTables.SavedAlbum, "id" );
+
+        Create.Index().OnTable( DataTables.SavedAlbum ).OnColumn( "id" ).Ascending().WithOptions().Clustered();
+        Create.Index().OnTable( DataTables.ExternalId ).OnColumn( "album_id" ).Ascending().WithOptions().Clustered();
+    }
+
+    public override void Down()
+    {
+    }
+}

--- a/api/Playlister/Data/scripts/007_alter_playlist_track_pk.sql
+++ b/api/Playlister/Data/scripts/007_alter_playlist_track_pk.sql
@@ -5,52 +5,14 @@ ALTER TABLE PlaylistTrack RENAME TO PlaylistTrack_old;
 
 CREATE TABLE IF NOT EXISTS "PlaylistTrack"
 (
-    "created_at"
-    DATETIME
-    NOT
-    NULL
-    DEFAULT
-    CURRENT_TIMESTAMP,
-    "modified_at"
-    DATETIME,
-    "track_id"
-    TEXT
-    NOT
-    NULL,
-    "playlist_id"
-    TEXT
-    NOT
-    NULL,
-    "playlist_snapshot_id"
-    TEXT,
-    "added_at"
-    DATETIME
-    NOT
-    NULL,
-    CONSTRAINT
-    "PK_PlaylistTrack"
-    PRIMARY
-    KEY
-(
-    "track_id",
-    "playlist_id",
-    "added_at"
-),
-    CONSTRAINT "fk_playlisttrack_trackid" FOREIGN KEY
-(
-    "track_id"
-) REFERENCES "Track"
-(
-    "id"
-),
-    CONSTRAINT "fk_playlisttrack_playlistid" FOREIGN KEY
-(
-    "playlist_id"
-) REFERENCES "Playlist"
-(
-    "id"
-)
-    );
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified_at" DATETIME, "track_id" TEXT NOT NULL,
+    "playlist_id" TEXT NOT NULL,
+    "playlist_snapshot_id" TEXT, "added_at" DATETIME NOT NULL,
+    CONSTRAINT "PK_PlaylistTrack" PRIMARY KEY ("track_id", "playlist_id", "added_at"),
+    CONSTRAINT "fk_playlisttrack_trackid" FOREIGN KEY ("track_id") REFERENCES "Track" ("id"),
+    CONSTRAINT "fk_playlisttrack_playlistid" FOREIGN KEY ("playlist_id") REFERENCES "Playlist" ("id")
+);
 
 INSERT INTO PlaylistTrack
 SELECT *

--- a/api/Playlister/Models/Album.cs
+++ b/api/Playlister/Models/Album.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.Json.Serialization;
-using Playlister.Models.SpotifyApi.Enums;
 
 namespace Playlister.Models;
 
@@ -22,9 +21,9 @@ public record Album
     public required string ReleaseDate { get; init; }
 
     [JsonPropertyName( "release_date_precision" )]
-    public ReleaseDatePrecision ReleaseDatePrecision { get; init; }
+    public required string ReleaseDatePrecision { get; init; }
 
-    [JsonPropertyName( "total_tracks" )] public int TotalTracks { get; init; }
+    [JsonPropertyName( "total_tracks" )] public required int TotalTracks { get; init; }
 
     [JsonPropertyName( "date_of_release" )]
     public DateTime DateOfRelease

--- a/api/Playlister/Models/SpotifyApi/Enums/AlbumType.cs
+++ b/api/Playlister/Models/SpotifyApi/Enums/AlbumType.cs
@@ -1,10 +1,11 @@
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Playlister.Models.SpotifyApi.Enums;
 
+[JsonConverter( typeof(JsonStringEnumConverter) )]
 public enum AlbumType
 {
-    [EnumMember( Value = "album" )] Album,
-    [EnumMember( Value = "single" )] Single,
-    [EnumMember( Value = "compilation" )] Compilation
+    Album,
+    Single,
+    Compilation
 }

--- a/api/Playlister/Models/SpotifyApi/Enums/ObjectType.cs
+++ b/api/Playlister/Models/SpotifyApi/Enums/ObjectType.cs
@@ -3,10 +3,11 @@ using System.Text.Json.Serialization;
 namespace Playlister.Models.SpotifyApi.Enums;
 
 [JsonConverter( typeof(JsonStringEnumConverter) )]
-public enum AlbumGroup
+public enum ObjectType
 {
     Album,
-    Single,
-    Compilation,
-    AppearsOn
+    Artist,
+    Playlist,
+    Track,
+    User
 }

--- a/api/Playlister/Models/SpotifyApi/Enums/ReleaseDatePrecision.cs
+++ b/api/Playlister/Models/SpotifyApi/Enums/ReleaseDatePrecision.cs
@@ -1,10 +1,11 @@
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Playlister.Models.SpotifyApi.Enums;
 
+[JsonConverter( typeof(JsonStringEnumConverter) )]
 public enum ReleaseDatePrecision
 {
-    [EnumMember( Value = "year" )] Year,
-    [EnumMember( Value = "month" )] Month,
-    [EnumMember( Value = "day" )] Day
+    Year,
+    Month,
+    Day
 }

--- a/api/Playlister/Models/SpotifyApi/ISpotifyApiObject.cs
+++ b/api/Playlister/Models/SpotifyApi/ISpotifyApiObject.cs
@@ -1,3 +1,5 @@
+using Playlister.Models.SpotifyApi.Enums;
+
 namespace Playlister.Models.SpotifyApi;
 
 public interface ISpotifyApiObject
@@ -15,7 +17,7 @@ public interface ISpotifyApiObject
     /// <summary>
     ///     The object type
     /// </summary>
-    public string Type { get; init; }
+    public ObjectType Type { get; init; }
 
     /// <summary>
     ///     The Spotify URI for the Object.

--- a/api/Playlister/Models/SpotifyApi/PlaylistItemTrackAlbumObject.cs
+++ b/api/Playlister/Models/SpotifyApi/PlaylistItemTrackAlbumObject.cs
@@ -1,0 +1,83 @@
+using Playlister.Models.SpotifyApi.Enums;
+
+namespace Playlister.Models.SpotifyApi;
+
+/// <summary>
+///     Returned in a <b>Playlist Item</b>'s <c>items.track.album</c> field. Unlike a <see cref="SimplifiedAlbumObject" />, there is no <c>label</c>
+///     field
+/// </summary>
+public record PlaylistItemTrackAlbumObject : ISpotifyApiObject
+{
+    /// <summary>
+    ///     The type of the album: one of <c>album</c>, <c>single</c>, or <c>compilation</c>.
+    /// </summary>
+    public required AlbumType AlbumType { get; init; }
+
+    /// <summary>
+    ///     The artists of the album.
+    ///     Each artist object includes a link in <c>href</c> to more detailed information about the artist.
+    /// </summary>
+    public required ICollection<SimplifiedArtistObject> Artists { get; init; }
+
+    /// <summary>
+    ///     The markets in which the album is available: <c>ISO 3166-1 alpha-2</c> country codes.
+    ///     Note that an album is considered available in a market when at least 1 of its tracks is available in that market.
+    /// </summary>
+    public required ICollection<string> AvailableMarkets { get; init; }
+
+    /// <summary>
+    ///     Known external URLs for this album.
+    /// </summary>
+    public required ExternalUrlObject ExternalUrls { get; init; }
+
+    /// <summary>
+    ///     The cover art for the album in various sizes, widest first.
+    /// </summary>
+    public required ICollection<ImageObject> Images { get; init; }
+
+    /// <summary>
+    ///     The name of the album. In case of an album takedown, the value may be an empty string.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     The date the album was first released, for example <c>1981</c>.
+    ///     Depending on the precision, it might be shown as <c>1981-12</c> or <c>1981-12-15</c>.
+    /// </summary>
+    public required string ReleaseDate { get; init; }
+
+    /// <summary>
+    ///     The precision with which <c>release_date</c> value is known: <c>year</c>, <c>month</c>, or <c>day</c>.
+    /// </summary>
+    public required string ReleaseDatePrecision { get; init; }
+
+    /// <summary>
+    ///     Included in the response when a content restriction is applied.
+    /// </summary>
+    public required AlbumRestrictionObject Restrictions { get; init; }
+
+    /// <summary>
+    ///     The total number of tracks in the album.
+    /// </summary>
+    public required int TotalTracks { get; init; }
+
+    /// <summary>
+    ///     A link to the Web API endpoint providing full details of the album.
+    /// </summary>
+    public required Uri Href { get; init; }
+
+    /// <summary>
+    ///     The Spotify ID for the album.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    ///     The object type: <c>album</c>
+    /// </summary>
+    public required ObjectType Type { get; init; }
+
+    /// <summary>
+    ///     The Spotify URI for the album.
+    /// </summary>
+    public required Uri Uri { get; init; }
+}

--- a/api/Playlister/Models/SpotifyApi/PrivateUserObject.cs
+++ b/api/Playlister/Models/SpotifyApi/PrivateUserObject.cs
@@ -1,3 +1,5 @@
+using Playlister.Models.SpotifyApi.Enums;
+
 namespace Playlister.Models.SpotifyApi;
 
 public record PrivateUserObject : ISpotifyApiObject
@@ -56,7 +58,7 @@ public record PrivateUserObject : ISpotifyApiObject
     /// <summary>
     ///     The object type: <c>user</c>.
     /// </summary>
-    public required string Type { get; init; }
+    public required ObjectType Type { get; init; }
 
     /// <summary>
     ///     The Spotify URI for this user.

--- a/api/Playlister/Models/SpotifyApi/SavedAlbumObject.cs
+++ b/api/Playlister/Models/SpotifyApi/SavedAlbumObject.cs
@@ -1,0 +1,23 @@
+namespace Playlister.Models.SpotifyApi;
+
+/// <summary>
+///     An Album saved in a Spotify user's 'Your Music' library
+/// </summary>
+public record SavedAlbumObject : PlaylistItemTrackAlbumObject
+{
+    /// <summary>
+    ///     The date and time the album was saved Timestamps are returned in <b>ISO 8601</b> format
+    ///     as Coordinated Universal Time (UTC) with a zero offset: <c>YYYY-MM-DDTHH:MM:SSZ</c>.
+    /// </summary>
+    public required string AddedAt { get; init; }
+
+    /// <summary>
+    ///     Known external IDs for the album.
+    /// </summary>
+    public required ExternalIdObject ExternalIds { get; init; }
+
+    /// <summary>
+    ///     The label associated with the album.
+    /// </summary>
+    public required string Label { get; init; }
+}

--- a/api/Playlister/Models/SpotifyApi/SimplifiedAlbumObject.cs
+++ b/api/Playlister/Models/SpotifyApi/SimplifiedAlbumObject.cs
@@ -1,90 +1,21 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Playlister.Models.SpotifyApi.Enums;
 
 namespace Playlister.Models.SpotifyApi;
 
-public record SimplifiedAlbumObject : ISpotifyApiObject
+/// <summary>
+///     Returned from the <i>Get Artist's Albums</i> endpoint <c>/artists/{id}/albums</c>
+/// </summary>
+/// <remarks>
+///     See <a href="https://developer.spotify.com/documentation/web-api/reference/get-an-artists-albums" />
+/// </remarks>
+public record SimplifiedAlbumObject : PlaylistItemTrackAlbumObject
 {
     /// <summary>
-    ///     The field is present when getting an artist’s albums.
+    ///     This field represents the relationship between the artist and the album.<br /><br />
     ///     Possible values are <c>album</c>, <c>single</c>, <c>compilation</c>, <c>appears_on</c>.
-    ///     Compare to <c>album_type</c> this field represents relationship between the artist and the album.
     /// </summary>
-    public string? AlbumGroup { get; init; }
-
-    /// <summary>
-    ///     The type of the album: one of <c>album</c>, <c>single</c>, or <c>compilation</c>.
-    /// </summary>
-    public required string AlbumType { get; init; }
-
-    /// <summary>
-    ///     The artists of the album.
-    ///     Each artist object includes a link in <c>href</c> to more detailed information about the artist.
-    /// </summary>
-    public required ICollection<SimplifiedArtistObject> Artists { get; init; }
-
-    /// <summary>
-    ///     The markets in which the album is available: <c>ISO 3166-1 alpha-2</c> country codes.
-    ///     Note that an album is considered available in a market when at least 1 of its tracks is available in that market.
-    /// </summary>
-    public required ICollection<string> AvailableMarkets { get; init; }
-
-    /// <summary>
-    ///     Known external URLs for this album.
-    /// </summary>
-    public required ExternalUrlObject ExternalUrls { get; init; }
-
-    /// <summary>
-    ///     The cover art for the album in various sizes, widest first.
-    /// </summary>
-    public required ICollection<ImageObject> Images { get; init; }
-
-    /// <summary>
-    ///     The name of the album. In case of an album takedown, the value may be an empty string.
-    /// </summary>
-    public required string Name { get; init; }
-
-    /// <summary>
-    ///     The date the album was first released, for example <c>1981</c>.
-    ///     Depending on the precision, it might be shown as <c>1981-12</c> or <c>1981-12-15</c>.
-    /// </summary>
-    public required string ReleaseDate { get; init; }
-
-    /// <summary>
-    ///     The precision with which <c>release_date</c> value is known: <c>year</c>, <c>month</c>, or <c>day</c>.
-    /// </summary>
-    [JsonConverter( typeof(StringEnumConverter) )]
-    public ReleaseDatePrecision ReleaseDatePrecision { get; init; }
-
-    /// <summary>
-    ///     Included in the response when a content restriction is applied.
-    /// </summary>
-    public required AlbumRestrictionObject Restrictions { get; init; }
-
-    /// <summary>
-    ///     The total number of tracks in the album.
-    /// </summary>
-    public int TotalTracks { get; init; }
-
-    /// <summary>
-    ///     A link to the Web API endpoint providing full details of the album.
-    /// </summary>
-    public required Uri Href { get; init; }
-
-    /// <summary>
-    ///     The Spotify ID for the album.
-    /// </summary>
-    public required string Id { get; init; }
-
-    /// <summary>
-    ///     The object type: <c>album</c>
-    /// </summary>
-    [JsonConverter( typeof(StringEnumConverter) )]
-    public required string Type { get; init; }
-
-    /// <summary>
-    ///     The Spotify URI for the album.
-    /// </summary>
-    public required Uri Uri { get; init; }
+    /// <remarks>
+    ///     The field is present when getting an artist’s albums.
+    /// </remarks>
+    public AlbumGroup AlbumGroup { get; init; }
 }

--- a/api/Playlister/Models/SpotifyApi/SimplifiedPlaylistObject.cs
+++ b/api/Playlister/Models/SpotifyApi/SimplifiedPlaylistObject.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Playlister.Models.SpotifyApi.Enums;
 
 namespace Playlister.Models.SpotifyApi;
 
@@ -37,10 +38,10 @@ public record SimplifiedPlaylistObject : ISpotifyApiObject
     public required PublicUserObject Owner { get; init; }
 
     /// <summary>
-    ///     The playlist’s public/private status:
-    ///     <c>true</c> the playlist is public,
-    ///     <c>false</c> the playlist is private,
-    ///     <c>null</c> the playlist status is not relevant.
+    ///     The playlist’s public/private status:<br /><br />
+    ///     <c>true</c> = the playlist is public,<br />
+    ///     <c>false</c> = the playlist is private,<br />
+    ///     <c>null</c> = the playlist status is not relevant.
     /// </summary>
     public bool? Public { get; init; }
 
@@ -70,7 +71,7 @@ public record SimplifiedPlaylistObject : ISpotifyApiObject
     /// <summary>
     ///     The object type: <c>playlist</c>
     /// </summary>
-    public required string Type { get; init; }
+    public required ObjectType Type { get; init; }
 
     /// <summary>
     ///     The Spotify URI for the playlist.

--- a/api/Playlister/Models/SpotifyApi/SimplifiedTrackObject.cs
+++ b/api/Playlister/Models/SpotifyApi/SimplifiedTrackObject.cs
@@ -1,3 +1,5 @@
+using Playlister.Models.SpotifyApi.Enums;
+
 namespace Playlister.Models.SpotifyApi;
 
 public record SimplifiedTrackObject : ISpotifyApiObject
@@ -35,7 +37,7 @@ public record SimplifiedTrackObject : ISpotifyApiObject
     /// <summary>
     ///     Whether the track is from a local file.
     /// </summary>
-    public required string IsLocal { get; init; }
+    public required bool IsLocal { get; init; }
 
     /// <summary>
     ///     Part of the response when Track Relinking is applied.
@@ -82,7 +84,7 @@ public record SimplifiedTrackObject : ISpotifyApiObject
     /// <summary>
     ///     The object type: <c>track</c>.
     /// </summary>
-    public required string Type { get; init; }
+    public required ObjectType Type { get; init; }
 
     /// <summary>
     ///     The Spotify URI for the track.

--- a/api/Playlister/Models/SpotifyApi/SimplifiedUserObject.cs
+++ b/api/Playlister/Models/SpotifyApi/SimplifiedUserObject.cs
@@ -1,3 +1,5 @@
+using Playlister.Models.SpotifyApi.Enums;
+
 namespace Playlister.Models.SpotifyApi;
 
 /// <summary>
@@ -12,7 +14,7 @@ public record SimplifiedUserObject
     /// <summary>
     ///     Always "user"
     /// </summary>
-    public required string Type { get; init; }
+    public required ObjectType Type { get; init; }
 
     public required string Uri { get; init; }
 }

--- a/api/Playlister/Models/SpotifyApi/TrackObject.cs
+++ b/api/Playlister/Models/SpotifyApi/TrackObject.cs
@@ -5,7 +5,7 @@ public record TrackObject : SimplifiedTrackObject
     /// <summary>
     ///     The album on which the track appears. The album object includes a link in <c>href</c> to full information about the album.
     /// </summary>
-    public required SimplifiedAlbumObject Album { get; init; }
+    public required PlaylistItemTrackAlbumObject Album { get; init; }
 
     /// <summary>
     ///     The artists who performed the track. Each artist object includes a link in <c>href</c> to more detailed information about the artist.

--- a/api/Playlister/Models/Track.cs
+++ b/api/Playlister/Models/Track.cs
@@ -18,7 +18,7 @@ public record Track
 
     [JsonPropertyName( "track_number" )] public int TrackNumber { get; init; }
 
-    public string AlbumId => Album.Id;
+    [JsonPropertyName( "album_id" )] public string AlbumId => Album.Id;
 
     /// <summary>
     ///     Flatten the track's artists and the track's album's artists into a single collection.
@@ -30,17 +30,23 @@ public record Track
     }
 
     /// <summary>
-    ///     Get Track/Artist TrackId pair for each artist on the track.
+    ///     Get Track/Artist ID pair for each artist on the track.
     /// </summary>
     /// <returns>Collection of track id, artist id tuples</returns>
-    public IEnumerable<object> GetArtistIdPairings()
+    public IEnumerable<ArtistTrackIdPair> GetArtistTrackIdPairings()
     {
         return Artists.Select(
-            a => new
+            a => new ArtistTrackIdPair
             {
                 TrackId = Id,
                 ArtistId = a.Id
             }
         );
+    }
+
+    public record ArtistTrackIdPair
+    {
+        public required string TrackId { get; init; }
+        public required string ArtistId { get; init; }
     }
 }

--- a/api/Playlister/Mvc/Controllers/HomeController.cs
+++ b/api/Playlister/Mvc/Controllers/HomeController.cs
@@ -90,7 +90,7 @@ public class HomeController : Controller
         Task.Factory.StartNew(
             () =>
             {
-                Thread.Sleep( 3_000 );
+                Thread.Sleep( 1_000 ); // gives the application time to return a response
                 _appLifetime.StopApplication();
             }
         );

--- a/api/Playlister/RefitClients/ISpotifyApi.cs
+++ b/api/Playlister/RefitClients/ISpotifyApi.cs
@@ -32,7 +32,7 @@ public interface ISpotifyApi
     /// <summary>
     ///     Get a list of the playlists owned or followed by the current Spotify user.
     /// </summary>
-    /// <param name="token"></param>
+    /// <param name="token">The user access token</param>
     /// <param name="offset">The index of the first item to return.</param>
     /// <param name="limit">The maximum number of items to return. Default: <c>20</c>. Minimum: <c>1</c>. Maximum: <c>50</c>.</param>
     /// <param name="ct"></param>
@@ -46,11 +46,27 @@ public interface ISpotifyApi
     );
 
     /// <summary>
+    ///     Get a list of the albums saved in the current Spotify user's 'Your Music' library.
+    /// </summary>
+    /// <param name="token">The user access token</param>
+    /// <param name="offset">The index of the first item to return.</param>
+    /// <param name="limit">The maximum number of items to return. Default: <c>20</c>. Minimum: <c>1</c>. Maximum: <c>50</c>.</param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    [Get( "/me/albums" )]
+    Task<PagingObject<SavedAlbumObject>> GetCurrentUserSavedAlbums(
+        [Authorize] string token,
+        int? offset,
+        int? limit,
+        CancellationToken ct
+    );
+
+    /// <summary>
     ///     Get full details of the items of a playlist owned by a Spotify user.
     ///     Applying the fields query
     ///     <c>fields=limit,next,previous,offset,limit,total,href,items(added_at,track(id,track_number,disc_number,duration_ms,name,artists(id,name),album(name,id,release_date,total_tracks,album_type,artists(id,name))))</c>
     /// </summary>
-    /// <param name="token"></param>
+    /// <param name="token">The user access token</param>
     /// <param name="playlistId">Playlist's Spotify ID</param>
     /// <param name="offset">The index of the first item to return. Default: <c>0</c> (the first object).</param>
     /// <param name="limit">The maximum number of items to return. Default: <c>100</c>. Minimum: <c>100</c>. Maximum: <c>100</c>.</param>
@@ -58,7 +74,7 @@ public interface ISpotifyApi
     /// <returns></returns>
     [Get(
         "/playlists/{playlistId}/tracks?market=from_token&fields=limit,next,previous,offset,limit,total,href"
-        + ",items(added_at,track(id,track_number,disc_number,duration_ms,name,artists(id,name),album(name,id,release_date,total_tracks,album_type,artists(id,name))))"
+        + ",items(added_at,track(id,track_number,disc_number,duration_ms,name,artists(id,name),album(name,id,release_date,release_date_precision,total_tracks,external_ids,album_type,type,artists(id,name))))"
     )]
     Task<PagingObject<PlaylistItem>> GetPlaylistTracksAsync(
         [Authorize] string token,

--- a/api/Playlister/Repositories/Implementations/PlaylistWriteRepository.cs
+++ b/api/Playlister/Repositories/Implementations/PlaylistWriteRepository.cs
@@ -138,6 +138,9 @@ public class PlaylistWriteRepository : IPlaylistWriteRepository
 
             await UpsertTracks( plist, tracks, conn, transaction ); // Track has FK to Album
 
+            /*
+             * Due to Foreign Keys, order of operations is important
+             */
             tasks.Add( UpsertPlaylistTracks( plist, items, conn, transaction ) ); // has FK to Playlist, Track
             tasks.Add( UpsertAlbumArtists( albums, conn, transaction ) ); // has FK to Album, Artist
             tasks.Add( UpsertTrackArtist( tracks, conn, transaction ) ); // has FK to Artist, Track
@@ -148,10 +151,10 @@ public class PlaylistWriteRepository : IPlaylistWriteRepository
         async Task UpsertPlaylist(
             Playlist plist,
             IDbConnection conn,
-            IDbTransaction dbTransaction
+            IDbTransaction dbTxn
         )
         {
-            await conn.UpsertAsync( SqlQueries.Upsert.Playlist, plist, dbTransaction );
+            await conn.UpsertAsync( SqlQueries.Upsert.Playlist, plist, dbTxn );
 
             _logger.LogDebug(
                 "{PlaylistTag} Upserted Playlist {Playlist} {PlaylistId}",
@@ -207,7 +210,7 @@ public class PlaylistWriteRepository : IPlaylistWriteRepository
             IDbTransaction dtTxn
         )
         {
-            ImmutableArray<object> trackArtists = tracks.SelectMany( x => x.GetArtistIdPairings() ).ToImmutableArray();
+            ImmutableArray<Track.ArtistTrackIdPair> trackArtists = tracks.SelectMany( x => x.GetArtistTrackIdPairings() ).ToImmutableArray();
 
             await conn.UpsertAsync( SqlQueries.Upsert.TrackArtist, trackArtists, dtTxn );
 

--- a/api/Playlister/Startup.cs
+++ b/api/Playlister/Startup.cs
@@ -39,7 +39,13 @@ public class Startup
             .AddJsonOptions(
                 options =>
                 {
-                    options.JsonSerializerOptions.Converters.Add( new JsonStringEnumConverter() );
+                    /*
+                     * IMPORTANT: Enums must also be marked with attribute `[JsonConverter( typeof(JsonStringEnumConverter) )]`
+                     */
+                    options.JsonSerializerOptions.Converters.Add(
+                        new JsonStringEnumConverter( JsonNamingPolicy.SnakeCaseLower, false )
+                    );
+
                     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
                 }
             );

--- a/api/Playlister/Views/Sync/Index.cshtml
+++ b/api/Playlister/Views/Sync/Index.cshtml
@@ -11,14 +11,16 @@
 </div>
 <script type="text/javascript">
     window.onload = async function () {
-        const resultsDivId= "sync-results";
-        const url = `${window.location.origin}/api/playlists/sync`
+        const resultsDivId= 'sync-results';
+        const base_url = `${window.location.origin}`
 
         document.getElementById(resultsDivId).innerHTML = '<p style="color:darkorange">Syncing</p>';
 
         try {
-            const response = await fetch(url, { method: "POST", credentials: 'include' });
+            const response = await fetch(`${base_url}/api/playlists/sync`, { method: 'POST', credentials: 'include' });
             document.getElementById(resultsDivId).innerHTML = resultsTable(await response.json());
+
+            await fetch(`${base_url}/stop-application`, {method: 'POST', credentials:'include'});
         } catch (e) {
             console.error(e);
             document.getElementById(resultsDivId).innerHTML = `<p><b style="color:darkred">Sync failed:</p><pre>${e.message}</pre></b>`;


### PR DESCRIPTION
- fix string enum serialization
- add new tables in preparation for saving Saved Albums to the database
- fix Spotify Objects models to match the Spotify API results/naming
- add call to /stop-application in Sync/Index.cshtml to end app after finishing syncing
- iSpotifyApi: add additional fields to GetPlaylistTracksAsync
- iSpotifyApi: add GetCurrentUserSavedAlbums